### PR TITLE
store card now shows items for sale

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,26 +1,26 @@
-import Link from 'next/link'
+import Link from 'next/link';
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, width = 'is-half' }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <header className="card-header">
-          <p className="card-header-title">
-            {store.name}
-          </p>
+          <p className="card-header-title">{store.name}</p>
         </header>
         <div className="card-content">
           <p className="content">
             Owner: {store.seller.first_name} {store.seller.last_name}
           </p>
-          <div className="content">
-            {store.description}
-          </div>
+          <div className="content">{store.description}</div>
+          <div className="content">Items for sale: {store.items_for_sale}</div>
         </div>
+
         <footer className="card-footer">
-          <Link href={`stores/${store.id}`} className="card-footer-item">View Store</Link>
+          <Link href={`stores/${store.id}`} className="card-footer-item">
+            View Store
+          </Link>
         </footer>
       </div>
     </div>
-  )
+  );
 }

--- a/components/store/detail.js
+++ b/components/store/detail.js
@@ -1,40 +1,45 @@
-import Link from 'next/link'
+import Link from 'next/link';
 
 export default function Detail({ store, isOwner, favorite, unfavorite }) {
   const ownerButtons = () => {
     return (
       <div className="buttons">
-        <Link href={`/stores/${store.id}/edit`} className="button is-primary is-inverted">
-            Edit Store
+        <Link
+          href={`/stores/${store.id}/edit`}
+          className="button is-primary is-inverted"
+        >
+          Edit Store
         </Link>
         <Link href="/products/new" className="button is-primary is-inverted">
-            Add a Product
+          Add a Product
         </Link>
       </div>
-    )
-  }
+    );
+  };
   const userButtons = () => {
     return (
       <>
-        {
-          store.is_favorite ?
-            <button className="button is-primary is-inverted" onClick={unfavorite}>
-              <span className="icon is-small">
-                <i className="fas fa-heart-broken"></i>
-              </span>
-              <span>Unfavorite Store</span>
-            </button>
-            :
-            <button className="button is-primary is-inverted" onClick={favorite}>
-              <span className="icon is-small">
-                <i className="fas fa-heart"></i>
-              </span>
-              <span>Favorite Store</span>
-            </button>
-        }
+        {store.is_favorite ? (
+          <button
+            className="button is-primary is-inverted"
+            onClick={unfavorite}
+          >
+            <span className="icon is-small">
+              <i className="fas fa-heart-broken"></i>
+            </span>
+            <span>Unfavorite Store</span>
+          </button>
+        ) : (
+          <button className="button is-primary is-inverted" onClick={favorite}>
+            <span className="icon is-small">
+              <i className="fas fa-heart"></i>
+            </span>
+            <span>Favorite Store</span>
+          </button>
+        )}
       </>
-    )
-  }
+    );
+  };
 
   return (
     <section className="hero is-primary mb-3">
@@ -43,25 +48,16 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
           <div className="navbar-menu">
             <div className="navbar-end">
               <span className="navbar-item">
-                {
-                  isOwner ?
-                    ownerButtons()
-                    :
-                    userButtons()
-                }
+                {isOwner ? ownerButtons() : userButtons()}
               </span>
             </div>
           </div>
         </nav>
       </div>
       <div className="hero-body">
-        <p className="title">
-          {store.name}
-        </p>
-        <p className="subtitle">
-          {store.description}
-        </p>
+        <p className="title">{store.name}</p>
+        <p className="subtitle">{store.description}</p>
       </div>
     </section>
-  )
+  );
 }

--- a/components/store/form.js
+++ b/components/store/form.js
@@ -1,25 +1,33 @@
-import { Input } from '../../components/form-elements'
-import CardLayout from '../card-layout'
+import { Input } from '../../components/form-elements';
+import CardLayout from '../card-layout';
 
-export default function StoreForm({ nameEl, descriptionEl, saveEvent, title, router, children }) {
+export default function StoreForm({
+  nameEl,
+  descriptionEl,
+  saveEvent,
+  title,
+  router,
+  children,
+}) {
   return (
     <CardLayout title={title}>
       <>
         {children}
-        <Input
-          id="name"
-          refEl={nameEl}
-          type="text"
-          placeholder="Store Name"
-        />
-        <textarea placeholder="Add a Description..." className="textarea" ref={descriptionEl}></textarea>
+        <Input id="name" refEl={nameEl} type="text" placeholder="Store Name" />
+        <textarea
+          placeholder="Add a Description..."
+          className="textarea"
+          ref={descriptionEl}
+        ></textarea>
       </>
       <>
-        <a className="card-footer-item" onClick={saveEvent}>Save</a>
-        <a className="card-footer-item" onClick={() => router.back()}>Cancel</a>
+        <a className="card-footer-item" onClick={saveEvent}>
+          Save
+        </a>
+        <a className="card-footer-item" onClick={() => router.back()}>
+          Cancel
+        </a>
       </>
     </CardLayout>
-  )
+  );
 }
-
-


### PR DESCRIPTION
# Description

I updated the card.js inside the store folder to show the amount of items sold by each store. The issue ticket says to show the complete list of items a store is selling, much like how the home page lists the items. But I'm not sure this is accurate. I think it would be better to render all items a store is selling in the details view after a user clicks on a store. 

To test this, make sure you have pulled the recent pull request from the api and run the server. Navigate to the store page, and you should see the store title, description, and the number of items sold. 

## Type of change

- [ ] New feature

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no errors
