### PR TITLE
Ft/favorite store

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,24 +1,29 @@
 import Link from 'next/link'
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, width = "is-half" }) {
+
+  // Determine which data structure we're dealing with
+  const storeData = store.seller && store.seller.store ? store.seller.store : store;
+  const ownerData = store.seller && store.seller.user ? store.seller.user : store.seller;
+
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <header className="card-header">
           <p className="card-header-title">
-            {store.name}
+            {storeData.name || "Unnamed Store"}
           </p>
         </header>
         <div className="card-content">
           <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
+            Owner: {ownerData.first_name || ""} {ownerData.last_name || ""}
           </p>
           <div className="content">
-            {store.description}
+            {storeData.description || "No description available"}
           </div>
         </div>
         <footer className="card-footer">
-          <Link href={`stores/${store.id}`} className="card-footer-item">View Store</Link>
+          <Link href={`stores/${storeData.id || ""}`} className="card-footer-item">View Store</Link>
         </footer>
       </div>
     </div>

--- a/components/store/detail.js
+++ b/components/store/detail.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export default function Detail({ store, isOwner, favorite, unfavorite }) {
+export default function Detail({ store, isOwner, favorite, unfavorite, favorites }) {
   const ownerButtons = () => {
     return (
       <div className="buttons">
@@ -14,10 +14,11 @@ export default function Detail({ store, isOwner, favorite, unfavorite }) {
     )
   }
   const userButtons = () => {
+    const isFavorite = favorites.some(fav => fav.seller.store.id === store.id)
     return (
       <>
         {
-          store.is_favorite ?
+          isFavorite ?
             <button className="button is-primary is-inverted" onClick={unfavorite}>
               <span className="icon is-small">
                 <i className="fas fa-heart-broken"></i>

--- a/data/stores.js
+++ b/data/stores.js
@@ -39,12 +39,15 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({
+      store_id: storeId
+    })
   })
 }
 
@@ -55,5 +58,14 @@ export function unfavoriteStore(storeId) {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+  })
+}
+
+
+export const getFavoriteStores = async () => {
+  return await fetchWithResponse('profile/favoritesellers', {
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`,
+    }
   })
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import CardLayout from '../components/card-layout'
 import Layout from '../components/layout'
 import Navbar from '../components/navbar'
@@ -6,24 +6,45 @@ import { ProductCard } from '../components/product/card'
 import { StoreCard } from '../components/store/card'
 import { useAppContext } from '../context/state'
 import { getUserProfile } from '../data/auth'
+import { getFavoriteStores } from "../data/stores"
 
 export default function Profile() {
   const { profile, setProfile } = useAppContext()
+  const [favorites, SetFavorites] = useState([])
 
   useEffect(() => {
-    getUserProfile().then((profileData) => {
-      if (profileData) {
-        setProfile(profileData)
-      }
-    })
+    fetchProfile()
   }, [])
+
+  useEffect(() => {
+    getFavoriteStores()
+      .then((data) => {
+        SetFavorites(data);
+      })
+      .catch((error) => {
+        console.error("Error fetching favorite stores:", error);
+      });
+  }, []);
+  
+  const fetchProfile = () => {
+    getUserProfile()
+      .then((profileData) => {
+        if (profileData) {
+          setProfile(profileData)
+        }
+      })
+      .catch((error) => {
+        console.error("Error fetching user profile:", error)
+      })
+  }
+
 
   return (
     <>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.favorites?.map(favorite => (
+            favorites?.map(favorite => (
               <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
             ))
           }

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -6,7 +6,7 @@ import { ProductCard } from '../../../components/product/card'
 import Detail from '../../../components/store/detail'
 import { useAppContext } from '../../../context/state'
 import { deleteProduct } from '../../../data/products'
-import { favoriteStore, getStoreById, unfavoriteStore } from '../../../data/stores'
+import { favoriteStore, getFavoriteStores, getStoreById, unfavoriteStore } from '../../../data/stores'
 
 export default function StoreDetail() {
   const { profile } = useAppContext()
@@ -14,6 +14,7 @@ export default function StoreDetail() {
   const { id } = router.query
   const [store, setStore] = useState({})
   const [isOwner, setIsOwner] = useState(false)
+  const [favorites, setFavorites] = useState([])
 
   useEffect(() => {
     if (id) {
@@ -22,6 +23,16 @@ export default function StoreDetail() {
     if (parseInt(id) === profile.store?.id) {
       setIsOwner(true)
     }
+  
+    const fetchFavorites = async () => {
+      try {
+        const data = await getFavoriteStores()
+        setFavorites(data)
+      } catch (error) {
+      }
+    }
+  
+    fetchFavorites()
   }, [id, profile])
 
   const refresh = () => getStoreById(id).then(storeData => {
@@ -44,7 +55,7 @@ export default function StoreDetail() {
 
   return (
     <>
-      <Detail store={store} isOwner={isOwner} favorite={favorite} unfavorite={unfavorite} />
+      <Detail store={store} isOwner={isOwner} favorite={favorite} unfavorite={unfavorite} favorites={favorites} />
       <div className="columns is-multiline">
         {
           store.products?.map(product => (


### PR DESCRIPTION
Favoriting Stores now renders in profile view & stores view appropriately. 

# Description

1. Updated `favoriteStore` fn in `stores.js`
2. Created `getFavoriteStores` fn in `stores.js`
3. Modified `card.js` & `detail.js` in the `store` component directory
4. Updated `index.js` in `pages/stores/[id]` to fetch favorites & pass prop
5. Updated `profile.js` in `pages` to fetch favorites to display in that view

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Step 1 - Make sure you're on the `ft/favorite-store` branch for both the API & client. 
- [ ] Step 2 - Navigate to `Stores` and click to `View Store`
- [ ] Step 3 - Click the Favorite Store Button & verify that the button turns to `Unfavorite`
- [ ] Go to `Profile` & Verify the store & details appear in the cards
