### PR TITLE
Ft/delete-favorite-store

### DIFF
--- a/data/stores.js
+++ b/data/stores.js
@@ -51,16 +51,16 @@ export function favoriteStore(storeId) {
   })
 }
 
-export function unfavoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/unfavorite`, {
+export function unfavoriteStore(favoriteId) {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
+    body: JSON.stringify({ favorite_id: favoriteId })
   })
 }
-
 
 export const getFavoriteStores = async () => {
   return await fetchWithResponse('profile/favoritesellers', {

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -46,11 +46,24 @@ export default function StoreDetail() {
   }
 
   const favorite = () => {
-    favoriteStore(id).then(refresh)
+    favoriteStore(id)
+      .then(() => getFavoriteStores())
+      .then(data => {
+        setFavorites(data)
+      })
+      .catch(error => console.error("Error favoriting store:", error))
   }
 
   const unfavorite = () => {
-    unfavoriteStore(id).then(refresh)
+    const favoriteId = favorites.find(fav => fav.seller.store.id === parseInt(id))?.id
+    if (favoriteId) {
+      unfavoriteStore(favoriteId)
+        .then(() => getFavoriteStores())
+        .then(data => {
+          setFavorites(data)
+        })
+        .catch(error => console.error("Error unfavoriting store:", error))
+    }
   }
 
   return (


### PR DESCRIPTION
# Description

Added unfavorite functionality & updated stores favorite state

Fixes # (issue)

1. Updated the `unfavorite` fn in `index.js` for stores[id]
2. Updated state rendering for favorites/unfavorites for the `store` cards
3. Updated the `unfavoriteStore` fetch fn to support new API delete support

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [ ] Go to the stores tab and favorite a store
- [ ] Verify the button changes to `unfavorite` and go to profile
- [ ] Verify the store is present
- [ ] Repeat steps, but this time unfavorite. 
