### PR TITLE
Ft/create user store

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -35,7 +35,7 @@ export default function Navbar() {
           {
             profile.store ?
               <>
-                <Link href={`/stores/${profile.store.id}`}><a className="navbar-item">View Your Store</a></Link>
+                <Link href={`/stores/${profile.store.id}`} className="navbar-item">View Your Store</Link>
                 <Link href="/products/new" className="navbar-item">Add a new Product</Link>
               </>
               :

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -33,9 +33,9 @@ export default function Navbar() {
           <Link href="/payments" className="navbar-item">Payment Methods</Link>
           <Link href="/profile" className="navbar-item">Profile</Link>
           {
-            profile.store ?
+            profile?.stores?.length > 0 ?
               <>
-                <Link href={`/stores/${profile.store.id}`} className="navbar-item">View Your Store</Link>
+                <Link href={`/stores/${profile.stores[0].id}`} className="navbar-item">View Your Store</Link>
                 <Link href="/products/new" className="navbar-item">Add a new Product</Link>
               </>
               :

--- a/data/stores.js
+++ b/data/stores.js
@@ -17,7 +17,7 @@ export function getStoreById(id) {
 }
 
 export function addStore(store) {
-  return fetchWithResponse(`stores`, {
+  return fetch(`http://localhost:8000/stores`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -25,6 +25,19 @@ export function addStore(store) {
     },
     body: JSON.stringify(store)
   })
+  .then(response => {
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return response.json();
+  })
+  .then(data => {
+    return data;
+  })
+  .catch(error => {
+    console.error('Error in addStore:', error);
+    throw error;
+  });
 }
 
 export function editStore(store) {

--- a/pages/stores/new.js
+++ b/pages/stores/new.js
@@ -24,7 +24,7 @@ export default function NewStore() {
         if (res && res.id) {
           setProfile({
             ...profile,
-            store: res
+            stores: [...profile.stores, res]
           });
           router.push(`/stores/${res.id}`);
         } else {

--- a/pages/stores/new.js
+++ b/pages/stores/new.js
@@ -14,17 +14,27 @@ export default function NewStore() {
   const router = useRouter()
 
   const saveStore = () => {
-    addStore({
+    const storeData = {
       name: nameEl.current.value,
       description: descriptionEl.current.value
-    }).then((res) => {
-      setProfile({
-        ...profile,
-        store: res
+    };
+    
+    addStore(storeData)
+      .then(res => {
+        if (res && res.id) {
+          setProfile({
+            ...profile,
+            store: res
+          });
+          router.push(`/stores/${res.id}`);
+        } else {
+          console.error('Store created but no ID returned:', res);
+        }
       })
-      router.push(`/stores/${res.id}`)
-    })
-  }
+      .catch(error => {
+        console.error('Error saving store:', error);
+      });
+  };
 
   return (
     <StoreForm nameEl={nameEl} descriptionEl={descriptionEl} saveEvent={saveStore} router={router} title="Create your store">


### PR DESCRIPTION
# Description

This PR now allows for a customer to create a store. It also currently supports creating multiple stores; however, I don't believe that is the best approach for the architecture of the basic site. Nevertheless, I made sure to follow our current model and issue ticket without interjecting my own opinion into the solution. 

Fixes # (issue)

1. Adjusted `navbar` logic to support profile.stores dropdown. 
2. Updated `addStore` fn to support error handling in the `data` directory
3. Updated `new.js` in the `stores` directory for error handling and `addStore` fn updated to reflect new stores serializer and profile context


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature

# How Should I Test This?

- [ ] With API running, navigate to the profile dropdown menu and select `Interested in Selling?`
- [ ] Create a new store with the form 
- [ ] Afterwards verify that you were redirected to the new store page
- [ ] Double-check without refreshing the page, that your dropdown profile menu now has replaced the `Interested in Selling` with `View Your Store` & `Add a new product`
- [ ] Adding a new product is outside of the scope of this PR
