### PR TITLE
Bug/profile fetch delay

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -13,7 +13,6 @@ export default function Navbar() {
       setIsLoggedIn(true);
     }
   }, [token]);
-  //hi its zach
 
   const showMobileNavbar = () => {
     hamburger.current.classList.toggle('is-active');

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -3,7 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useAppContext } from '../context/state';
 
 export default function Navbar() {
-  const { token, profile } = useAppContext();
+  const { token, profile, setProfile } = useAppContext();
   const hamburger = useRef();
   const navbar = useRef();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -63,6 +63,7 @@ export default function Navbar() {
             onClick={() => {
               localStorage.removeItem('token');
               setIsLoggedIn(false);
+              setProfile({})
             }}
           >
             Log out

--- a/context/state.js
+++ b/context/state.js
@@ -8,24 +8,22 @@ export function AppWrapper({ children }) {
   const [profile, setProfile] = useState({})
   const [token, setToken] = useState("")
   const router = useRouter()
+  const [isLoading, setIsLoading] = useState(true); // Loading state
 
   useEffect(() => {
-    setToken(localStorage.getItem('token'))
-  }, [])
-
-  useEffect(() => {
-    const authRoutes = ['/login', '/register']
-    if (token) {
-      localStorage.setItem('token', token)
-      if (!authRoutes.includes(router.pathname)) {
-        getUserProfile().then((profileData) => {
-          if (profileData) {
-            setProfile(profileData)
-          }
-        })
-      }
+    const storedToken = localStorage.getItem('token');
+    setToken(storedToken);
+    if (storedToken) {
+      getUserProfile().then((profileData) => {
+        setProfile(profileData);
+        setIsLoading(false); // Profile fetched, stop loading
+      });
+    } else {
+      setIsLoading(false); // No token, stop loading
     }
-  }, [token])
+  }, [token]);
+
+  if (isLoading) return <div>Loading...</div>; // Optionally show a loading spinner
 
   return (
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>

--- a/pages/login.js
+++ b/pages/login.js
@@ -5,28 +5,33 @@ import { Input } from '../components/form-elements'
 import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import { useAppContext } from '../context/state'
-import { login } from '../data/auth'
+import { getUserProfile, login } from '../data/auth'
 
 export default function Login() {
-  const {setToken} = useAppContext()
+  const {setToken, setProfile} = useAppContext()
   const username = useRef('')
   const password = useRef('')
   const router = useRouter()
 
   const submit = (e) => {
-    e.preventDefault()
+    e.preventDefault();
     const user = {
       username: username.current.value,
       password: password.current.value,
-    }
+    };
 
     login(user).then((res) => {
       if (res.token) {
-        setToken(res.token)
-        router.push('/')
+        localStorage.setItem('token', res.token); // Ensure token is saved
+        setToken(res.token);
+        // Fetch profile after setting the token
+        getUserProfile().then(profileData => {
+          setProfile(profileData); // Set profile in context
+          router.push('/');
+        });
       }
-    })
-  }
+    });
+  };
 
   return (
     <div className="columns is-centered">


### PR DESCRIPTION
# Description

`Login` now set's profile during initial mount. 

Fixes # (issue)

1. Updated `navbar.js` logout function to reset profile to `{}` in order to force a sign in to view `My-Store` view
2. Updated `login.js` to setProfile on initial render, so that the My-Store Nav component is available when logging in. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [x] Step 1 - Log in with an authorized user
- [x] Step 2 - Verify that the My-Store nav component is available if the user has a store
- [x] Step 3 - _(Optional)_: Log in with another authorized user, verify the My-Store component is present (given the user has a store) or is not present (given the user does NOT have a store)

## Notes

_I did find another bug that is very similar as it relates to registering a user._ I figured it best to keep the issue tickets separate and to tackle that if we have time or decide to. 
